### PR TITLE
add option to use externally managed config file

### DIFF
--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -1,7 +1,7 @@
 name: Build and push Wine based image
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+
 jobs:
   build-push:
     runs-on: ubuntu-latest
@@ -21,4 +21,3 @@ jobs:
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/enshrouded-dedicated-server:wine-latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/enshrouded-dedicated-server:wine-${{ github.event.release.tag_name }}

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Run Enshrouded dedicated server in a container. Optionally includes helm chart f
 
 The processes within the container do **NOT** run as root. Everything runs as the user steam (gid:10000/uid:10000 by default). If you exec into the container, you will drop into `/home/steam` as the steam user. Enshrouded will be installed to `/home/steam/enshrouded`. Any persistent volumes should be mounted to `/home/steam/enshrouded/savegame` and be owned by 10000:10000. 
 
+If you absolutely require to run the process in the container as a gid/uid other than 10000, you can build your own image based on my dockerfile. Instructions are covered [Here](https://github.com/jsknnr/enshrouded-server/issues/51)
 
 ### Proton and Wine based images
 
-The `latest` tag is now based on the Proton build instead of Wine. This should be seamless. Outside of `latest`, there is `wine-$realease_version` and `proton-$release_version` with `$release_version` being the version of the release from GitHub.
+The `latest` tag is now based on the Proton build instead of Wine. This should be seamless. Outside of `latest`, there is `wine-$realease_version` and `proton-$release_version` with `$release_version` being the version of the release from GitHub. I am no longer updating the Wine version of this image.
 
 ### Ports
 
@@ -32,6 +33,7 @@ The `latest` tag is now based on the Proton build instead of Wine. This should b
 | QUERY_PORT | Port for steam query of server | 15637 | False |
 | SERVER_SLOTS | Number of slots for connections (Max 16) | 16 | False |
 | SERVER_IP | IP address for server to listen on | 0.0.0.0 | False |
+| EXTERNAL_CONFIG | If you would rather manually supply a config file, set this to true (1) | 0 | False | 
 
 **Note:** SERVER_IP is ignored if using Helm because that isn't how Kubernetes works.
 

--- a/container/proton/Dockerfile
+++ b/container/proton/Dockerfile
@@ -8,6 +8,7 @@ ENV STEAM_APP_ID "2278520"
 ENV HOME "/home/steam"
 ENV ENSHROUDED_PATH "/home/steam/enshrouded"
 ENV ENSHROUDED_CONFIG "${ENSHROUDED_PATH}/enshrouded_server.json"
+ENV EXTERNAL_CONFIG 0
 ENV GE_PROTON_VERSION "9-18"
 ENV GE_PROTON_URL "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton${GE_PROTON_VERSION}/GE-Proton${GE_PROTON_VERSION}.tar.gz"
 ENV STEAMCMD_PATH="/home/steam/steamcmd"

--- a/container/proton/entrypoint.sh
+++ b/container/proton/entrypoint.sh
@@ -55,9 +55,11 @@ if [ $? != 0 ]; then
 fi
 
 # Copy example server config if not already present
-if ! [ -f "${ENSHROUDED_PATH}/enshrouded_server.json" ]; then
-    echo "$(timestamp) INFO: Enshrouded server config not present, copying example"
-    cp /home/steam/enshrouded_server_example.json ${ENSHROUDED_PATH}/enshrouded_server.json
+if [ $EXTERNAL_CONFIG -eq 0 ]; then
+    if ! [ -f "${ENSHROUDED_PATH}/enshrouded_server.json" ]; then
+        echo "$(timestamp) INFO: Enshrouded server config not present, copying example"
+        cp /home/steam/enshrouded_server_example.json ${ENSHROUDED_PATH}/enshrouded_server.json
+    fi
 fi
 
 # Check for proper save permissions
@@ -73,16 +75,20 @@ fi
 rm "${ENSHROUDED_PATH}/savegame/test"
 
 # Modify server config to match our arguments
-echo "$(timestamp) INFO: Updating Enshrouded Server configuration"
-tmpfile=$(mktemp)
-jq --arg n "$SERVER_NAME" '.name = $n' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
-if [ -n "$SERVER_PASSWORD" ]; then
-    jq --arg p "$SERVER_PASSWORD" '.userGroups[].password = $p' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
+if [ $EXTERNAL_CONFIG -eq 0 ]; then
+    echo "$(timestamp) INFO: Updating Enshrouded Server configuration"
+    tmpfile=$(mktemp)
+    jq --arg n "$SERVER_NAME" '.name = $n' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
+    if [ -n "$SERVER_PASSWORD" ]; then
+        jq --arg p "$SERVER_PASSWORD" '.userGroups[].password = $p' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
+    fi
+    jq --arg g "$GAME_PORT" '.gamePort = ($g | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
+    jq --arg q "$QUERY_PORT" '.queryPort = ($q | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
+    jq --arg s "$SERVER_SLOTS" '.slotCount = ($s | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
+    jq --arg i "$SERVER_IP" '.ip = $i' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
+else
+    echo "$(timestamp) INFO: EXTERNAL_CONFIG set to true, not updating Enshrouded Server configuration"
 fi
-jq --arg g "$GAME_PORT" '.gamePort = ($g | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
-jq --arg q "$QUERY_PORT" '.queryPort = ($q | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
-jq --arg s "$SERVER_SLOTS" '.slotCount = ($s | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
-jq --arg i "$SERVER_IP" '.ip = $i' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
 
 # Wine talks too much and it's annoying
 export WINEDEBUG=-all


### PR DESCRIPTION
Added env var EXTERNAL_CONFIG can be set to true/1 or false/0(by default). If user wants to use something like a configmap or manually editing a mounted file directly this option can be set to true to force the startup script to not modify the config.