### PR TITLE
Fix graceful shutdown on proton

### DIFF
--- a/container/proton/entrypoint.sh
+++ b/container/proton/entrypoint.sh
@@ -126,12 +126,15 @@ while [ $timeout -lt 11 ]; do
     echo "$(timestamp) INFO: Waiting for enshrouded_server.exe to be running"
 done
 
-# Hold us open until we recieve a SIGTERM
+# Hold us open until we recieve a SIGTERM by opening a job waiting for the process to finish then calling `wait`
+tail --pid=$enshrouded_pid -f /dev/null &
 wait
 
-# Handle post SIGTERM from here
-# Hold us open until WSServer-Linux pid closes, indicating full shutdown, then go home
-tail --pid=$enshrouded_pid -f /dev/null
+# Handle post SIGTERM from here (SIGTERM will cancel the `wait` immediately even though the job is not done yet)
+# Check if the enshrouded_server.exe process is still running, and if so, wait for it to close, indicating full shutdown, then go home
+if ps -e | grep "enshrouded_serv"; then
+    tail --pid=$enshrouded_pid -f /dev/null
+fi
 
 # o7
 echo "$(timestamp) INFO: Shutdown complete."


### PR DESCRIPTION
Related to Issue #65 

The current code appears to fail to gracefully shutdown the server when the container is stopped, affecting only the proton build.  In my testing the process called by the entrypoint script to start the server itself appears to merely start other processes and does not remain running for the life of the server process, and as a result, the bash job for it stops, and the entrypoint script proceeds past the `wait` and runs the tail command. In my own testing, when SIGTERM is received in this state, the trap function for shutdown is not called and nothing happens, resulting in Docker forcefully terminating the processes in the container after a timeout.
 
The best solution I could come up with is to tail command to wait for the actual server process and background that before calling wait. This frees everything up so as to allow the shutdown trap function to work as intended when the script receives SIGTERM from Docker stopping the container. A second call to tail is required to cause the script to wait while the server finishes shutting down, but I wrapped it in an `if` condition so it isn't called if the server process ends by itself.

Let me know if this would be acceptable to merge or if there are any issue or concerns