### PR TITLE
Remove unnecessary mentions to game port

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Static Badge](https://img.shields.io/badge/DockerHub-blue)](https://hub.docker.com/r/sknnr/enshrouded-dedicated-server) ![Docker Pulls](https://img.shields.io/docker/pulls/sknnr/enshrouded-dedicated-server) [![Static Badge](https://img.shields.io/badge/GitHub-green)](https://github.com/jsknnr/enshrouded-server) ![GitHub Repo stars](https://img.shields.io/github/stars/jsknnr/enshrouded-server)
 
-
 Run Enshrouded dedicated server in a container. Optionally includes helm chart for running in Kubernetes.
 
 **Disclaimer:** This is not an official image. No support, implied or otherwise is offered to any end user by the author or anyone else. Feel free to do what you please with the contents of this repo.
+
 ## Usage
 
-The processes within the container do **NOT** run as root. Everything runs as the user steam (gid:10000/uid:10000 by default). If you exec into the container, you will drop into `/home/steam` as the steam user. Enshrouded will be installed to `/home/steam/enshrouded`. Any persistent volumes should be mounted to `/home/steam/enshrouded/savegame` and be owned by 10000:10000. 
+The processes within the container do **NOT** run as root. Everything runs as the user steam (gid:10000/uid:10000 by default). If you exec into the container, you will drop into `/home/steam` as the steam user. Enshrouded will be installed to `/home/steam/enshrouded`. Any persistent volumes should be mounted to `/home/steam/enshrouded/savegame` and be owned by 10000:10000.
 
 If you absolutely require to run the process in the container as a gid/uid other than 10000, you can build your own image based on my dockerfile. Instructions are covered [Here](https://github.com/jsknnr/enshrouded-server/issues/51)
 
@@ -18,22 +18,21 @@ The `latest` tag is now based on the Proton build instead of Wine. This should b
 
 ### Ports
 
-| Port | Protocol | Default |
-| ---- | -------- | ------- |
-| Game Port | UDP | 15636 |
-| Query Port | UDP | 15637 |
+| Port       | Protocol | Default |
+| ---------- | -------- | ------- |
+| Game Port  | UDP      | 15636   |
+| Query Port | UDP      | 15637   |
 
 ### Environment Variables
 
-| Name | Description | Default | Required |
-| ---- | ----------- | ------- | -------- |
-| SERVER_NAME | Name for the Server | Enshrouded Containerized | False |
-| SERVER_PASSWORD | Password for the server | None | False |
-| GAME_PORT | Port for server connections | 15636 | False |
-| QUERY_PORT | Port for steam query of server | 15637 | False |
-| SERVER_SLOTS | Number of slots for connections (Max 16) | 16 | False |
-| SERVER_IP | IP address for server to listen on | 0.0.0.0 | False |
-| EXTERNAL_CONFIG | If you would rather manually supply a config file, set this to true (1) | 0 | False | 
+| Name            | Description                                                             | Default                  | Required |
+| --------------- | ----------------------------------------------------------------------- | ------------------------ | -------- |
+| SERVER_NAME     | Name for the Server                                                     | Enshrouded Containerized | False    |
+| SERVER_PASSWORD | Password for the server                                                 | None                     | False    |
+| PORT            | Port for steam query of server                                          | 15637                    | False    |
+| SERVER_SLOTS    | Number of slots for connections (Max 16)                                | 16                       | False    |
+| SERVER_IP       | IP address for server to listen on                                      | 0.0.0.0                  | False    |
+| EXTERNAL_CONFIG | If you would rather manually supply a config file, set this to true (1) | 0                        | False    |
 
 **Note:** SERVER_IP is ignored if using Helm because that isn't how Kubernetes works.
 
@@ -52,8 +51,7 @@ docker run \
   --env=SERVER_NAME='Enshrouded Containerized Server' \
   --env=SERVER_SLOTS=16 \
   --env=SERVER_PASSWORD='ChangeThisPlease' \
-  --env=GAME_PORT=15636 \
-  --env=QUERY_PORT=15637 \
+  --env=PORT=15637 \
   sknnr/enshrouded-dedicated-server:latest
 ```
 
@@ -72,8 +70,9 @@ docker-compose down
 ```
 
 compose.yaml file:
+
 ```yaml
-version: '3'
+version: "3"
 services:
   enshrouded:
     image: sknnr/enshrouded-dedicated-server:latest
@@ -83,8 +82,7 @@ services:
     environment:
       - SERVER_NAME=Enshrouded Containerized
       - SERVER_PASSWORD=PleaseChangeMe
-      - GAME_PORT=15636
-      - QUERY_PORT=15637
+      - PORT=15637
       - SERVER_SLOTS=16
       - SERVER_IP=0.0.0.0
     volumes:
@@ -92,7 +90,6 @@ services:
 
 volumes:
   enshrouded-persistent-data:
-
 ```
 
 ### Podman
@@ -110,13 +107,14 @@ podman run \
   --env=SERVER_NAME='Enshrouded Containerized Server' \
   --env=SERVER_SLOTS=16 \
   --env=SERVER_PASSWORD='ChangeThisPlease' \
-  --env=GAME_PORT=15636 \
-  --env=QUERY_PORT=15637 \
+  --env=PORT=15637 \
   docker.io/sknnr/enshrouded-dedicated-server:latest
 ```
 
 ### Quadlet
+
 To run the container with Podman's new quadlet subsystem, make a file under (when running as root) /etc/containers/systemd/enshrouded.container containing:
+
 ```text
 [Unit]
 Description=Enshrouded Game Server
@@ -128,8 +126,7 @@ PublishPort=15636-15637:15636-15637/udp
 ContainerName=enshrouded-server
 Environment=SERVER_NAME="Enshrouded Containerized Server"
 Environment=SERVER_PASSWORD="ChangeThisPlease"
-Environment=GAME_PORT=15636
-Environment=QUERY_PORT=15637
+Environment=PORT=15637
 Environment=SERVER_SLOTS=16
 
 [Service]

--- a/container/compose.yaml
+++ b/container/compose.yaml
@@ -3,13 +3,11 @@ services:
   enshrouded:
     image: sknnr/enshrouded-dedicated-server:latest
     ports:
-      - "15636:15636/udp"
       - "15637:15637/udp"
     environment:
       - SERVER_NAME=Enshrouded Containerized
       - SERVER_PASSWORD=PleaseChangeMe
-      - GAME_PORT=15636
-      - QUERY_PORT=15637
+      - PORT=15637
       - SERVER_SLOTS=16
       - SERVER_IP=0.0.0.0
     volumes:

--- a/container/proton/enshrouded_server_example.json
+++ b/container/proton/enshrouded_server_example.json
@@ -3,7 +3,6 @@
   "saveDirectory": "./savegame",
   "logDirectory": "./logs",
   "ip": "0.0.0.0",
-  "gamePort": 15636,
   "queryPort": 15637,
   "slotCount": 16,
   "gameSettingsPreset": "Default",

--- a/container/proton/entrypoint.sh
+++ b/container/proton/entrypoint.sh
@@ -24,14 +24,9 @@ if [ -z "$SERVER_PASSWORD" ]; then
     echo "$(timestamp) WARN: SERVER_PASSWORD not set, server will be open to the public"
 fi
 
-if [ -z "$GAME_PORT" ]; then
-    GAME_PORT='15636'
-    echo "$(timestamp) WARN: GAME_PORT not set, using default: 15636"
-fi
-
-if [ -z "$QUERY_PORT" ]; then
-    QUERY_PORT='15637'
-    echo "$(timestamp) WARN: QUERY_PORT not set, using default: 15637"
+if [ -z "$PORT" ]; then
+    PORT='15637'
+    echo "$(timestamp) WARN: PORT not set, using default: 15637"
 fi
 
 if [ -z "$SERVER_SLOTS" ]; then
@@ -82,8 +77,7 @@ if [ $EXTERNAL_CONFIG -eq 0 ]; then
     if [ -n "$SERVER_PASSWORD" ]; then
         jq --arg p "$SERVER_PASSWORD" '.userGroups[].password = $p' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
     fi
-    jq --arg g "$GAME_PORT" '.gamePort = ($g | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
-    jq --arg q "$QUERY_PORT" '.queryPort = ($q | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
+    jq --arg q "$PORT" '.queryPort = ($q | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
     jq --arg s "$SERVER_SLOTS" '.slotCount = ($s | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
     jq --arg i "$SERVER_IP" '.ip = $i' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
 else

--- a/container/wine/enshrouded_server_example.json
+++ b/container/wine/enshrouded_server_example.json
@@ -3,7 +3,6 @@
   "saveDirectory": "./savegame",
   "logDirectory": "./logs",
   "ip": "0.0.0.0",
-  "gamePort": 15636,
   "queryPort": 15637,
   "slotCount": 16,
   "gameSettingsPreset": "Default",

--- a/container/wine/entrypoint.sh
+++ b/container/wine/entrypoint.sh
@@ -24,14 +24,9 @@ if [ -z "$SERVER_PASSWORD" ]; then
     echo "$(timestamp) WARN: SERVER_PASSWORD not set, server will be open to the public"
 fi
 
-if [ -z "$GAME_PORT" ]; then
-    GAME_PORT='15636'
-    echo "$(timestamp) WARN: GAME_PORT not set, using default: 15636"
-fi
-
-if [ -z "$QUERY_PORT" ]; then
-    QUERY_PORT='15637'
-    echo "$(timestamp) WARN: QUERY_PORT not set, using default: 15637"
+if [ -z "$PORT" ]; then
+    PORT='15637'
+    echo "$(timestamp) WARN: PORT not set, using default: 15637"
 fi
 
 if [ -z "$SERVER_SLOTS" ]; then
@@ -79,8 +74,7 @@ jq --arg n "$SERVER_NAME" '.name = $n' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "
 if [ -n "$SERVER_PASSWORD" ]; then
     jq --arg p "$SERVER_PASSWORD" '.userGroups[].password = $p' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
 fi
-jq --arg g "$GAME_PORT" '.gamePort = ($g | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
-jq --arg q "$QUERY_PORT" '.queryPort = ($q | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
+jq --arg q "$PORT" '.queryPort = ($q | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
 jq --arg s "$SERVER_SLOTS" '.slotCount = ($s | tonumber)' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
 jq --arg i "$SERVER_IP" '.ip = $i' ${ENSHROUDED_CONFIG} > "$tmpfile" && mv "$tmpfile" $ENSHROUDED_CONFIG
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -10,8 +10,7 @@ Enshrouded dedicated server.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| config.gamePort | int | `15636` |  |
-| config.queryPort | int | `15637` |  |
+| config.queryPort | int | `15637` | The port used by the game server |
 | config.serverName | string | `"Enshrouded Server"` | Server name |
 | config.serverPassword | string | `""` | Server password. If not set, password will be generated randomly. |
 | config.serverPasswordExistingSecretName | string | `""` | Existing secret name for server password. Must contain key named "password". If set `serverPassword` will be ignored. |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -39,20 +39,15 @@ spec:
             secretKeyRef:
               name: {{ include "enshrouded.passwordSecretName" . }}
               key: serverPassword
-        - name: GAME_PORT
-          value: {{ .Values.config.gamePort | squote }}
-        - name: QUERY_PORT
-          value: {{ .Values.config.queryPort | squote }}
+        - name: PORT
+          value: {{ .Values.config.port | squote }}
         - name: SERVER_SLOTS
           value: {{ .Values.config.serverSlots | squote }}
         - name: EXTERNAL_CONFIG
           value: {{ .Values.config.externalConfig | squote }}
         ports:
-        - name: game-port
-          containerPort: {{ .Values.config.gamePort | int }}
-          protocol: UDP
-        - name: query-port
-          containerPort: {{ .Values.config.queryPort | int }}
+        - name: port
+          containerPort: {{ .Values.config.port | int }}
           protocol: UDP
         volumeMounts:
         - name: data

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -16,19 +16,12 @@ spec:
   externalIPs: {{ . | toYaml | nindent 4 }}
   {{- end }}
   ports:
-  - name: game-port
-    port: {{ .Values.config.gamePort | int }}
-    targetPort: game-port
+  - name: port
+    port: {{ .Values.config.port | int }}
+    targetPort: port
     protocol: UDP
     {{- if eq .Values.service.type "NodePort" }}
-    nodePort: {{ .Values.config.gamePort | int }}
-    {{- end }}
-  - name: query-port
-    port: {{ .Values.config.queryPort | int }}
-    targetPort: query-port
-    protocol: UDP
-    {{- if eq .Values.service.type "NodePort" }}
-    nodePort: {{ .Values.config.queryPort| int }}
+    nodePort: {{ .Values.config.port| int }}
     {{- end }}
   selector:
     app: "{{ .Chart.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -25,8 +25,7 @@ config:
   serverPassword: ""
   # -- Existing secret name for server password. Must contain key named "password". If set `serverPassword` will be ignored.
   serverPasswordExistingSecretName: ""
-  gamePort: 15636
-  queryPort: 15637
+  port: 15637
   # -- Number of server slots
   serverSlots: 16
   externalConfig: 0

--- a/makefile
+++ b/makefile
@@ -15,11 +15,11 @@ HASH := $(shell git rev-parse --short HEAD)
 CONTAINER_NAME := enshrouded-test
 VOLUME_NAME := enshrouded-data
 BUILDAH_BUILD_OPTS := --format docker -f ./container/wine/Dockerfile
-PODMAN_RUN_OPTS := --name $(CONTAINER_NAME) -d --mount type=volume,source=$(VOLUME_NAME),target=/home/steam/enshrouded/savegame -p 15636:15636/udp -p 15637:15637/udp --env=SERVER_NAME='Enshrouded Containerized Server' --env=SERVER_SLOTS=16 --env=SERVER_PASSWORD='ChangeThisPlease' --env=GAME_PORT=15636 --env=QUERY_PORT=15637
+PODMAN_RUN_OPTS := --name $(CONTAINER_NAME) -d --mount type=volume,source=$(VOLUME_NAME),target=/home/steam/enshrouded/savegame -p 15636:15636/udp -p 15637:15637/udp --env=SERVER_NAME='Enshrouded Containerized Server' --env=SERVER_SLOTS=16 --env=SERVER_PASSWORD='ChangeThisPlease' --env=PORT=15637
 PROTON_CONTAINER_NAME := enshrouded-proton-test
 PROTON_VOLUME_NAME := enshrouded-proton-data
 PROTON_DOCKER_BUILD_OPTS := -f ./container/proton/Dockerfile
-PROTON_DOCKER_RUN_OPTS := --name $(PROTON_CONTAINER_NAME) -d --mount type=volume,source=$(PROTON_VOLUME_NAME),target=/home/steam/enshrouded/savegame -p 15636:15636/udp -p 15637:15637/udp --env=SERVER_NAME='Enshrouded Containerized Server' --env=SERVER_SLOTS=16 --env=SERVER_PASSWORD='ChangeThisPlease' --env=GAME_PORT=15636 --env=QUERY_PORT=15637
+PROTON_DOCKER_RUN_OPTS := --name $(PROTON_CONTAINER_NAME) -d --mount type=volume,source=$(PROTON_VOLUME_NAME),target=/home/steam/enshrouded/savegame -p 15636:15636/udp -p 15637:15637/udp --env=SERVER_NAME='Enshrouded Containerized Server' --env=SERVER_SLOTS=16 --env=SERVER_PASSWORD='ChangeThisPlease' --env=PORT=15637
 
 # Makefile targets
 .PHONY: build run cleanup build-proton run-proton cleanup-proton


### PR DESCRIPTION
The Enshrouded dedicated server [no longer uses the game port](https://enshrouded.zendesk.com/hc/en-us/articles/19191581489309-Server-Roles-Configuration#h_01HZ29QC64ANFG7N4X39XRZ1MK) and only uses the query port. Keeping both in the configuration and opening both ports in the docker container is unnecessary and causes confusion. This change simplifies the configuration by having just a single port (called just "port" for brevity and simplicity).