### PR TITLE
Create savegame directory when missing

### DIFF
--- a/container/proton/Dockerfile
+++ b/container/proton/Dockerfile
@@ -9,7 +9,7 @@ ENV HOME "/home/steam"
 ENV ENSHROUDED_PATH "/home/steam/enshrouded"
 ENV ENSHROUDED_CONFIG "${ENSHROUDED_PATH}/enshrouded_server.json"
 ENV EXTERNAL_CONFIG 0
-ENV GE_PROTON_VERSION "9-18"
+ENV GE_PROTON_VERSION "9-25"
 ENV GE_PROTON_URL "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton${GE_PROTON_VERSION}/GE-Proton${GE_PROTON_VERSION}.tar.gz"
 ENV STEAMCMD_PATH="/home/steam/steamcmd"
 ENV STEAM_SDK64_PATH="/home/steam/.steam/sdk64"

--- a/container/proton/entrypoint.sh
+++ b/container/proton/entrypoint.sh
@@ -62,6 +62,11 @@ if [ $EXTERNAL_CONFIG -eq 0 ]; then
     fi
 fi
 
+# Check that savegame directory exists, if not create
+if ! [ -d "${ENSHROUDED_PATH}/savegame" ]; then
+    mkdir -p "${ENSHROUDED_PATH}/savegame"
+fi
+
 # Check for proper save permissions
 if ! touch "${ENSHROUDED_PATH}/savegame/test"; then
     echo ""


### PR DESCRIPTION
Automatically create the 'savegame' directory when it is missing. Resolves launch problem when mounting /home/steam/enshrouded to external storage since 'savegame' is only automatically created during container build process.