### PR TITLE
fixed regression in server json config when not using external config…

### DIFF
--- a/container/enshrouded_server_example.json
+++ b/container/enshrouded_server_example.json
@@ -52,23 +52,13 @@
 	},
 	"userGroups": [
 		{
-			"name": "Admin",
-			"password": "changemeplease",
+			"name": "Default",
+			"password": "",
 			"canKickBan": true,
 			"canAccessInventories": true,
 			"canEditWorld": true,
 			"canEditBase": true,
 			"canExtendBase": true,
-			"reservedSlots": 0
-		},
-		{
-			"name": "Friend",
-			"password": "alsochangemeplease",
-			"canKickBan": false,
-			"canAccessInventories": true,
-			"canEditWorld": true,
-			"canEditBase": true,
-			"canExtendBase": false,
 			"reservedSlots": 0
 		}
 	],

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$EXTERNAL_CONFIG" -eq 0 ]; then
     [ -z "${SERVER_PASSWORD:-}" ] && \
         echo "$(timestamp) WARN: SERVER_PASSWORD not set, server will be public"
 else
-    echo "$(timestamp) INFO: EXTERNAL_CONFIG is set, checking for presence and permmission"
+    echo "$(timestamp) INFO: EXTERNAL_CONFIG is set, checking for presence and permission"
     if [ ! -f "$ENSHROUDED_CONFIG" ]; then
         echo "$(timestamp) ERROR: EXTERNAL_CONFIG set but config not found at $ENSHROUDED_CONFIG"
         exit 1
@@ -42,6 +42,7 @@ else
         echo "$(timestamp) INFO: Adjust ownership and restart the container (e.g. sudo chown 10000:10000 /path/to/your/enshrouded_server.json)"
         exit 1
     fi
+    echo "$(timestamp) INFO: External config found and ownership looks good"
 fi
 
 ########################################
@@ -66,6 +67,7 @@ fi
 # Config handling
 ########################################
 
+# Only modify config if we are not using external config
 if [ "$EXTERNAL_CONFIG" -eq 0 ]; then
     if [ ! -f "$ENSHROUDED_CONFIG" ]; then
         echo "$(timestamp) INFO: Server config not present, copying example"
@@ -88,21 +90,29 @@ if [ "$EXTERNAL_CONFIG" -eq 0 ]; then
       | .ip = $i
       | (if $p != "" then .userGroups[]?.password = $p else . end)
       ' "$ENSHROUDED_CONFIG" > "$tmpfile" \
-      && mv "$tmpfile" "$ENSHROUDED_CONFIG"
+      && mv "$tmpfile" "$ENSHROUDED_CONFIG" && chmod 644 "$ENSHROUDED_CONFIG"
 fi
 
+# We will use the query port for monitoring server state instead of pid
+# Retrieve port form the config as that is absolute source of truth
+QUERY_PORT=$(jq -r '.queryPort' "$ENSHROUDED_CONFIG")
+# Convert port to hex
+QUERY_PORT_HEX=$(printf '%04X' "$QUERY_PORT")
+
 ########################################
-# Savegame & logs
+# Permissions & logs
 ########################################
 
 mkdir -p "$ENSHROUDED_PATH/savegame" "$ENSHROUDED_PATH/logs"
 
+# Check savegame directory is writable
 if ! touch "$ENSHROUDED_PATH/savegame/.permtest"; then
     echo "$(timestamp) ERROR: Savegame directory is not writable"
     exit 1
 fi
 rm -f "$ENSHROUDED_PATH/savegame/.permtest"
 
+# Link logs to stdout
 : > "$ENSHROUDED_PATH/logs/enshrouded_server.log"
 ln -sf /proc/1/fd/1 "$ENSHROUDED_PATH/logs/enshrouded_server.log"
 
@@ -117,22 +127,28 @@ echo "$(timestamp) INFO: Starting Enshrouded Dedicated Server"
 "${STEAMCMD_PATH}/compatibilitytools.d/GE-Proton${GE_PROTON_VERSION}/proton" \
     run "$ENSHROUDED_PATH/enshrouded_server.exe" &
 
-# Wait for process to start
-for i in {1..10}; do
-    if pgrep -f enshrouded_server.exe >/dev/null; then
+# Wait for server to be up by checking UDP port
+echo "$(timestamp) INFO: Waiting for server to be up and listening on UDP port $QUERY_PORT"
+
+for i in {1..30}; do
+    if awk '{print $2}' /proc/net/udp | grep -q ":$QUERY_PORT_HEX$"; then
+        echo "$(timestamp) INFO: Server is up and listening on UDP port $QUERY_PORT"
         break
     fi
-    sleep 6
-    echo "$(timestamp) INFO: Waiting for enshrouded_server.exe"
-    if [ "$i" -eq 10 ]; then
-        echo "$(timestamp) ERROR: Timed out waiting for server to start"
+
+    if [ "$i" -eq 30 ]; then
+        echo "$(timestamp) ERROR: Timed out waiting for server to be up and listening on UDP port $QUERY_PORT"
         exit 1
     fi
+
+    sleep 2
 done
 
-# Hold us open until we recieve a SIGTERM
-while pgrep -f '[e]nshrouded_server.exe' >/dev/null; do
-    sleep 10
+# Hold the container open while the server is running by monitoring the UDP port
+echo "$(timestamp) INFO: Monitoring server heartbeat via UDP port $QUERY_PORT"
+
+while awk '{print $2}' /proc/net/udp | grep -q ":$QUERY_PORT_HEX$"; do
+    sleep 3
 done
 
 exit 0


### PR DESCRIPTION
- fixed regression in example server json config
- fixed potential race condition when transitioning from starting to running

known issue:
- When **NOT** using external config, we can only handle 1 user group (default) when setting a password on the server. If multiple user groups share the same password the server will silently exit. If you need more than 1 user group, please use the external config option. My guess is that if you are wanting more than 1 user group you are already using external config anyway, so I will likely leave it as is for now.