### PR TITLE
Config file ownership check for Kubernetes

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -36,10 +36,10 @@ else
         echo "$(timestamp) ERROR: EXTERNAL_CONFIG set but config not found at $ENSHROUDED_CONFIG"
         exit 1
     fi
-    if [ "$(stat -c '%u:%g' "$ENSHROUDED_CONFIG")" != "10000:10000" ]; then
+    if [ "$(stat -c '%g' "$ENSHROUDED_CONFIG")" != "10000" ]; then
         echo "$(timestamp) ERROR: External config ownership must be 10000:10000"
         echo "$(timestamp) INFO: Current ownership is $(stat -c '%u:%g' "$ENSHROUDED_CONFIG")"
-        echo "$(timestamp) INFO: Adjust ownership and restart the container (e.g. sudo chown 10000:10000 /path/to/your/enshrouded_server.json)"
+        echo "$(timestamp) INFO: Adjust group ownership and restart the container (e.g. sudo chgrp 10000 /path/to/your/enshrouded_server.json)"
         exit 1
     fi
     echo "$(timestamp) INFO: External config found and ownership looks good"


### PR DESCRIPTION
Make sure group ownership is correct, not user ownership. In Kubernetes when mounting a ConfigMap as a Volume you cannot control the user ownership of the file, only group ownership. So you end up with a config file owned by root: 0:10000.